### PR TITLE
Fix gitignore for `BuildConstants.java`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,7 +169,7 @@ networktables.json
 **/venv
 
 # Version file
-src/main/java/org/littletonrobotics/frc2023/BuildConstants.java
+src/main/java/frc/robot/BuildConstants.java
 
 # Arm trajectory cache
 src/main/deploy/arm_trajectory_cache.json


### PR DESCRIPTION
I noticed that the path for `BuildConstants.java` in the gitignore was still using the 2023 robot code class path. Probably better to not include every build in the git history 😇